### PR TITLE
Change base image and upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,35 @@
-FROM deepmind/kapitan:0.29
+FROM python:3.11-slim AS builder
+
 
 USER root
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        libffi-dev \
+        libmagic1
+
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 WORKDIR /opt/venv/
 
 COPY . /opt/venv/
-RUN python -m venv /opt/venv && pip install --no-cache-dir -r requirements.txt
 
+RUN pip install -r requirements.txt
+
+FROM python:3.11-slim
+
+COPY --from=builder /opt/venv /opt/venv
+USER root
+WORKDIR /opt/venv/
+
+RUN apt-get update \
+    && apt-get install -y libmagic1
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 #USER kapitan see https://github.com/kapicorp/tesoro/issues/1
-ENTRYPOINT [ "/opt/venv/bin/python", "-m", "tesoro" ]
+ENTRYPOINT [ "python", "-m", "tesoro" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-aiohttp==3.8.1
+aiohttp==3.8.4
 jsonpatch==1.32
-prometheus-client==0.12.0
+prometheus-client==0.16
+kapitan==0.31.0

--- a/tests/test_tranform.py
+++ b/tests/test_tranform.py
@@ -14,9 +14,14 @@ class TestPreprare(unittest.TestCase):
         k8s_obj = {
             "apiVersion": "v1",
             "kind": "Secret",
-            "metadata": {"name": "some-secret", "labels": {"tesoro.kapicorp.com": "enabled"},},
+            "metadata": {
+                "name": "some-secret",
+                "labels": {"tesoro.kapicorp.com": "enabled"},
+            },
             "type": "Opaque",
-            "data": {"file1": b64encode(bytes(ref_tag.encode())),},
+            "data": {
+                "file1": b64encode(bytes(ref_tag.encode())),
+            },
         }
         transformations = prepare_obj("request_uid", k8s_obj)
 
@@ -44,9 +49,14 @@ class TestTransform(unittest.TestCase):
         k8s_obj = {
             "apiVersion": "v1",
             "kind": "Secret",
-            "metadata": {"name": "some-secret", "labels": {"tesoro.kapicorp.com": "enabled"},},
+            "metadata": {
+                "name": "some-secret",
+                "labels": {"tesoro.kapicorp.com": "enabled"},
+            },
             "type": "Opaque",
-            "data": {"file1": b64encode(bytes(ref_tag.encode())),},
+            "data": {
+                "file1": b64encode(bytes(ref_tag.encode())),
+            },
         }
         transformations = prepare_obj("request_uid", k8s_obj)
         # reveal base64_ref
@@ -67,9 +77,14 @@ class TestTransform(unittest.TestCase):
         k8s_obj = {
             "apiVersion": "v1",
             "kind": "Secret",
-            "metadata": {"name": "some-secret", "labels": {"tesoro.kapicorp.com": "enabled"},},
+            "metadata": {
+                "name": "some-secret",
+                "labels": {"tesoro.kapicorp.com": "enabled"},
+            },
             "type": "Opaque",
-            "data": {"file1": b64encode(bytes(ref_tag.encode())),},
+            "data": {
+                "file1": b64encode(bytes(ref_tag.encode())),
+            },
         }
         transformations = prepare_obj("request_uid", k8s_obj)
         # reveal base64_ref


### PR DESCRIPTION
Use python:3.11-slim as the base image and install kapitan as dependency instead of using kapitan as base image. Kapitan is still using python-3.7 image